### PR TITLE
Add kanban columns and task creation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,10 @@
 import { AppShell } from "@/components/AppShell";
+import { KanbanBoard } from "@/components/KanbanBoard";
 
 export default function Home() {
   return (
     <AppShell>
-      <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900 sm:p-8">
+      <section className="mb-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900 sm:p-8">
         <div className="max-w-3xl">
           <p className="text-sm font-medium text-slate-500 dark:text-slate-400">
             1 ボード固定のカンバン型 ToDo アプリ
@@ -18,6 +19,7 @@ export default function Home() {
           </p>
         </div>
       </section>
+      <KanbanBoard />
     </AppShell>
   );
 }

--- a/components/KanbanBoard.tsx
+++ b/components/KanbanBoard.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { KanbanColumn } from "@/components/KanbanColumn";
+import { TaskForm } from "@/components/TaskForm";
+import { createTask } from "@/lib/task";
+import {
+  TASK_STATUS_LABELS,
+  TASK_STATUSES,
+  type Task,
+  type TaskStatus,
+} from "@/types/task";
+
+export function KanbanBoard() {
+  const [tasks, setTasks] = useState<Task[]>([]);
+
+  const tasksByStatus = useMemo(() => {
+    return TASK_STATUSES.reduce<Record<TaskStatus, Task[]>>(
+      (groupedTasks, status) => {
+        groupedTasks[status] = tasks.filter((task) => task.status === status);
+        return groupedTasks;
+      },
+      {
+        todo: [],
+        inProgress: [],
+        done: [],
+      },
+    );
+  }, [tasks]);
+
+  return (
+    <div className="grid gap-6">
+      <TaskForm
+        onCreateTask={(input) => {
+          setTasks((currentTasks) => [
+            createTask({
+              title: input.title,
+              description: input.description,
+            }),
+            ...currentTasks,
+          ]);
+        }}
+      />
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        {TASK_STATUSES.map((status) => (
+          <KanbanColumn
+            key={status}
+            title={TASK_STATUS_LABELS[status]}
+            status={status}
+            tasks={tasksByStatus[status]}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/KanbanColumn.tsx
+++ b/components/KanbanColumn.tsx
@@ -1,0 +1,32 @@
+import { TaskCard } from "@/components/TaskCard";
+import type { Task, TaskStatus } from "@/types/task";
+
+type KanbanColumnProps = {
+  title: string;
+  status: TaskStatus;
+  tasks: Task[];
+};
+
+export function KanbanColumn({ title, tasks }: KanbanColumnProps) {
+  return (
+    <section className="flex min-h-80 flex-col rounded-xl border border-slate-200 bg-slate-100/70 p-3 dark:border-slate-800 dark:bg-slate-900/70">
+      <div className="mb-3 flex items-center justify-between gap-3 px-1">
+        <h2 className="text-sm font-semibold text-slate-800 dark:text-slate-100">
+          {title}
+        </h2>
+        <span className="rounded-full bg-white px-2.5 py-1 text-xs font-semibold text-slate-600 shadow-sm dark:bg-slate-950 dark:text-slate-300">
+          {tasks.length}
+        </span>
+      </div>
+      <div className="flex flex-1 flex-col gap-3">
+        {tasks.length > 0 ? (
+          tasks.map((task) => <TaskCard key={task.id} task={task} />)
+        ) : (
+          <div className="flex flex-1 items-center justify-center rounded-lg border border-dashed border-slate-300 bg-white/70 p-6 text-center text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-950/50 dark:text-slate-400">
+            タスクはありません。
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/components/TaskCard.tsx
+++ b/components/TaskCard.tsx
@@ -1,0 +1,24 @@
+import type { Task } from "@/types/task";
+
+type TaskCardProps = {
+  task: Task;
+};
+
+export function TaskCard({ task }: TaskCardProps) {
+  return (
+    <article className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-950">
+      <h3 className="text-sm font-semibold leading-6 text-slate-950 dark:text-slate-50">
+        {task.title}
+      </h3>
+      {task.description ? (
+        <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-600 dark:text-slate-300">
+          {task.description}
+        </p>
+      ) : (
+        <p className="mt-2 text-sm text-slate-400 dark:text-slate-500">
+          詳細は未入力です。
+        </p>
+      )}
+    </article>
+  );
+}

--- a/components/TaskForm.tsx
+++ b/components/TaskForm.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+
+type TaskFormProps = {
+  onCreateTask: (input: { title: string; description: string }) => void;
+};
+
+export function TaskForm({ onCreateTask }: TaskFormProps) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+
+  const trimmedTitle = title.trim();
+
+  return (
+    <form
+      className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+      onSubmit={(event) => {
+        event.preventDefault();
+
+        if (!trimmedTitle) {
+          return;
+        }
+
+        onCreateTask({
+          title: trimmedTitle,
+          description,
+        });
+        setTitle("");
+        setDescription("");
+      }}
+    >
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)_auto] lg:items-end">
+        <label className="grid gap-2">
+          <span className="text-sm font-medium text-slate-700 dark:text-slate-200">
+            タイトル
+          </span>
+          <input
+            type="text"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="例: 見積書を確認する"
+            className="h-10 rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-950 shadow-sm outline-none transition placeholder:text-slate-400 focus:border-slate-500 focus:ring-2 focus:ring-slate-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-50 dark:focus:border-slate-400 dark:focus:ring-slate-800"
+          />
+        </label>
+        <label className="grid gap-2">
+          <span className="text-sm font-medium text-slate-700 dark:text-slate-200">
+            詳細
+          </span>
+          <input
+            type="text"
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            placeholder="任意でメモを入力"
+            className="h-10 rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-950 shadow-sm outline-none transition placeholder:text-slate-400 focus:border-slate-500 focus:ring-2 focus:ring-slate-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-50 dark:focus:border-slate-400 dark:focus:ring-slate-800"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={!trimmedTitle}
+          className="inline-flex h-10 items-center justify-center rounded-md bg-slate-950 px-4 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-slate-300 dark:bg-slate-100 dark:text-slate-950 dark:hover:bg-white dark:focus:ring-slate-500 dark:focus:ring-offset-slate-950 dark:disabled:bg-slate-700 dark:disabled:text-slate-400"
+        >
+          タスクを追加
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/lib/task.ts
+++ b/lib/task.ts
@@ -1,0 +1,24 @@
+import type { Task, TaskStatus } from "@/types/task";
+
+type CreateTaskInput = {
+  title: string;
+  description: string;
+  status?: TaskStatus;
+};
+
+export function createTask({
+  title,
+  description,
+  status = "todo",
+}: CreateTaskInput): Task {
+  const now = new Date().toISOString();
+
+  return {
+    id: crypto.randomUUID(),
+    title: title.trim(),
+    description: description.trim(),
+    status,
+    createdAt: now,
+    updatedAt: now,
+  };
+}


### PR DESCRIPTION
## Summary
- Add the KanbanBoard, KanbanColumn, TaskForm, and TaskCard components.
- Render the fixed Todo / In Progress / Done columns with empty states and task counts.
- Add in-memory task creation that places new tasks in the Todo column.

## Test plan
- [x] npm run lint
- [x] npm run build
- [x] Verify the three kanban columns render in the browser
- [x] Verify a task can be created and appears in the Todo column

Closes #7
Closes #8
Closes #9

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kanban board interface to the home page for viewing and managing tasks organized by status
  * Introduced task creation form with title and description input fields
  * Each status column displays task count badges and empty-state messaging when no tasks exist
  * Tasks are automatically grouped and displayed across their respective status columns

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/micci184/todo-app/pull/18)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->