### PR TITLE
Support card reordering within columns

### DIFF
--- a/components/KanbanBoard.tsx
+++ b/components/KanbanBoard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { KanbanColumn } from "@/components/KanbanColumn";
 import { createTask } from "@/lib/task";
 import { loadAppState, saveAppState } from "@/lib/storage";
@@ -17,7 +17,7 @@ export function KanbanBoard() {
   const [dropTargetStatus, setDropTargetStatus] = useState<TaskStatus | null>(
     null,
   );
-  const hasLoadedStoredState = useRef(false);
+  const [hasLoadedStoredState, setHasLoadedStoredState] = useState(false);
 
   const updateTask = (
     taskId: string,
@@ -43,23 +43,49 @@ export function KanbanBoard() {
     );
   };
 
-  const changeTaskStatus = (taskId: string, status: TaskStatus) => {
-    setTasks((currentTasks) =>
-      currentTasks.map((task) =>
-        task.id === taskId && task.status !== status
-          ? {
-              ...task,
-              status,
-              updatedAt: new Date().toISOString(),
-            }
-          : task,
-      ),
-    );
-  };
-
   const finishDragging = () => {
     setDraggingTaskId(null);
     setDropTargetStatus(null);
+  };
+
+  const moveTask = (
+    taskId: string,
+    targetStatus: TaskStatus,
+    targetTaskId?: string,
+  ) => {
+    setTasks((currentTasks) => {
+      const draggedTask = currentTasks.find((task) => task.id === taskId);
+
+      if (!draggedTask || targetTaskId === taskId) {
+        return currentTasks;
+      }
+
+      const shouldUpdateStatus = draggedTask.status !== targetStatus;
+      const movedTask = shouldUpdateStatus
+        ? {
+            ...draggedTask,
+            status: targetStatus,
+            updatedAt: new Date().toISOString(),
+          }
+        : draggedTask;
+      const tasksWithoutDragged = currentTasks.filter(
+        (task) => task.id !== taskId,
+      );
+
+      if (targetTaskId && targetTaskId !== taskId) {
+        const targetTaskIndex = tasksWithoutDragged.findIndex(
+          (task) => task.id === targetTaskId,
+        );
+
+        if (targetTaskIndex >= 0) {
+          const reorderedTasks = [...tasksWithoutDragged];
+          reorderedTasks.splice(targetTaskIndex, 0, movedTask);
+          return reorderedTasks;
+        }
+      }
+
+      return [...tasksWithoutDragged, movedTask];
+    });
   };
 
   const createNewTask = (input: { title: string; description: string }) => {
@@ -75,8 +101,8 @@ export function KanbanBoard() {
   useEffect(() => {
     const frameId = requestAnimationFrame(() => {
       const storedState = loadAppState();
-      hasLoadedStoredState.current = true;
       setTasks(storedState.tasks);
+      setHasLoadedStoredState(true);
     });
 
     return () => {
@@ -85,12 +111,12 @@ export function KanbanBoard() {
   }, []);
 
   useEffect(() => {
-    if (!hasLoadedStoredState.current) {
+    if (!hasLoadedStoredState) {
       return;
     }
 
     saveAppState({ tasks });
-  }, [tasks]);
+  }, [hasLoadedStoredState, tasks]);
 
   const tasksByStatus = useMemo(() => {
     return TASK_STATUSES.reduce<Record<TaskStatus, Task[]>>(
@@ -105,6 +131,14 @@ export function KanbanBoard() {
       },
     );
   }, [tasks]);
+
+  if (!hasLoadedStoredState) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-slate-100/70 p-6 text-center text-sm text-slate-500 dark:border-slate-800 dark:bg-slate-900/70 dark:text-slate-400">
+        タスクを読み込んでいます。
+      </div>
+    );
+  }
 
   return (
     <div className="grid gap-5 sm:gap-6">
@@ -123,9 +157,9 @@ export function KanbanBoard() {
             onDragEnterColumn={setDropTargetStatus}
             onDragEndTask={finishDragging}
             onCreateTask={status === "todo" ? createNewTask : undefined}
-            onDropTask={(targetStatus) => {
+            onDropTask={(targetStatus, targetTaskId) => {
               if (draggingTaskId) {
-                changeTaskStatus(draggingTaskId, targetStatus);
+                moveTask(draggingTaskId, targetStatus, targetTaskId);
               }
 
               finishDragging();

--- a/components/KanbanColumn.tsx
+++ b/components/KanbanColumn.tsx
@@ -19,7 +19,7 @@ type KanbanColumnProps = {
   onDragEnterColumn: (status: TaskStatus) => void;
   onDragEndTask: () => void;
   onCreateTask?: (input: { title: string; description: string }) => void;
-  onDropTask: (status: TaskStatus) => void;
+  onDropTask: (status: TaskStatus, targetTaskId?: string) => void;
 };
 
 export function KanbanColumn({
@@ -88,6 +88,8 @@ export function KanbanColumn({
               onDelete={onDeleteTask}
               onDragStart={onDragStartTask}
               onDragEnd={onDragEndTask}
+              onDragEnter={() => onDragEnterColumn(status)}
+              onDrop={() => onDropTask(status, task.id)}
             />
           ))
         ) : (

--- a/components/TaskCard.tsx
+++ b/components/TaskCard.tsx
@@ -12,7 +12,9 @@ type TaskCardProps = {
   ) => void;
   onDelete: (taskId: string) => void;
   onDragStart: (taskId: string) => void;
+  onDragEnter: () => void;
   onDragEnd: () => void;
+  onDrop: () => void;
 };
 
 export function TaskCard({
@@ -21,7 +23,9 @@ export function TaskCard({
   onUpdate,
   onDelete,
   onDragStart,
+  onDragEnter,
   onDragEnd,
+  onDrop,
 }: TaskCardProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
@@ -113,6 +117,16 @@ export function TaskCard({
         event.dataTransfer.effectAllowed = "move";
         event.dataTransfer.setData("text/plain", task.id);
         onDragStart(task.id);
+      }}
+      onDragEnter={onDragEnter}
+      onDragOver={(event: DragEvent<HTMLElement>) => {
+        event.preventDefault();
+        event.dataTransfer.dropEffect = "move";
+      }}
+      onDrop={(event: DragEvent<HTMLElement>) => {
+        event.preventDefault();
+        event.stopPropagation();
+        onDrop();
       }}
       onDragEnd={onDragEnd}
     >


### PR DESCRIPTION
## Summary
- Allow cards to be reordered by dropping them onto another card in the same column.
- Preserve existing cross-column drag and drop behavior while using the task array order as the saved display order.
- Avoid rendering the board before localStorage has loaded so the saved order is not overwritten during hydration.

## Test plan
- [x] npm run lint
- [x] npm run build
- [x] Browser verified same-column reordering
- [x] Browser verified ordering persists after reload

Closes #22


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tasks can now be reordered within the same column using drag-and-drop.
  * Added a loading indicator when retrieving saved tasks.

* **Improvements**
  * Enhanced drag-and-drop handling with improved visual feedback during card interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/micci184/todo-app/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->