### PR TITLE
Allow adding cards from every column

### DIFF
--- a/components/KanbanBoard.tsx
+++ b/components/KanbanBoard.tsx
@@ -88,25 +88,30 @@ export function KanbanBoard() {
     });
   };
 
-  const createNewTask = (input: { title: string; description: string }) => {
+  const createNewTask = (input: {
+    title: string;
+    description: string;
+    status: TaskStatus;
+  }) => {
     setTasks((currentTasks) => [
       createTask({
         title: input.title,
         description: input.description,
+        status: input.status,
       }),
       ...currentTasks,
     ]);
   };
 
   useEffect(() => {
-    const frameId = requestAnimationFrame(() => {
+    const timeoutId = window.setTimeout(() => {
       const storedState = loadAppState();
       setTasks(storedState.tasks);
       setHasLoadedStoredState(true);
-    });
+    }, 0);
 
     return () => {
-      cancelAnimationFrame(frameId);
+      window.clearTimeout(timeoutId);
     };
   }, []);
 
@@ -156,7 +161,12 @@ export function KanbanBoard() {
             onDragStartTask={setDraggingTaskId}
             onDragEnterColumn={setDropTargetStatus}
             onDragEndTask={finishDragging}
-            onCreateTask={status === "todo" ? createNewTask : undefined}
+            onCreateTask={(input) =>
+              createNewTask({
+                ...input,
+                status,
+              })
+            }
             onDropTask={(targetStatus, targetTaskId) => {
               if (draggingTaskId) {
                 moveTask(draggingTaskId, targetStatus, targetTaskId);

--- a/components/KanbanColumn.tsx
+++ b/components/KanbanColumn.tsx
@@ -38,6 +38,7 @@ export function KanbanColumn({
 }: KanbanColumnProps) {
   const [newTaskTitle, setNewTaskTitle] = useState("");
   const trimmedTitle = newTaskTitle.trim();
+  const newTaskTitleId = `new-task-title-${status}`;
 
   const createTaskFromTitle = () => {
     if (!onCreateTask || !trimmedTitle) {
@@ -105,11 +106,11 @@ export function KanbanColumn({
               createTaskFromTitle();
             }}
           >
-            <label className="sr-only" htmlFor="new-task-title">
+            <label className="sr-only" htmlFor={newTaskTitleId}>
               新しいタスクのタイトル
             </label>
             <textarea
-              id="new-task-title"
+              id={newTaskTitleId}
               value={newTaskTitle}
               onChange={(event) => setNewTaskTitle(event.target.value)}
               onKeyDown={(event) => {


### PR DESCRIPTION
## Summary
- Enable the existing inline card composer in Todo, In Progress, and Done columns.
- Create new cards with the status of the column where they are added.
- Use unique textarea IDs per column and avoid RAF-dependent initial localStorage loading.

## Test plan
- [x] npm run lint
- [x] npm run build
- [x] Browser verified adding cards from Todo, In Progress, and Done
- [x] Browser verified added cards persist after reload

Closes #23


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * You can now create new tasks directly within any column on the Kanban board. Each new task is automatically assigned to the corresponding column status.

* **Bug Fixes**
  * Improved screen reader accessibility by fixing duplicate identifier issues when creating new tasks across different columns on the board.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/micci184/todo-app/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->