### PR TITLE
Add card detail modal editing

### DIFF
--- a/components/CardDetailModal.tsx
+++ b/components/CardDetailModal.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useEffect, useId, useState } from "react";
+import { TASK_STATUS_LABELS, type Task } from "@/types/task";
+
+type CardDetailModalProps = {
+  task: Task;
+  onClose: () => void;
+  onUpdateTask: (
+    taskId: string,
+    input: Pick<Task, "title" | "description">,
+  ) => void;
+};
+
+export function CardDetailModal({
+  task,
+  onClose,
+  onUpdateTask,
+}: CardDetailModalProps) {
+  const titleInputId = useId();
+  const descriptionInputId = useId();
+  const modalTitleId = useId();
+  const [title, setTitle] = useState(task.title);
+  const [description, setDescription] = useState(task.description);
+
+  const trimmedTitle = title.trim();
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+
+  const saveTask = () => {
+    if (!trimmedTitle) {
+      return;
+    }
+
+    onUpdateTask(task.id, {
+      title: trimmedTitle,
+      description,
+    });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-slate-950/50 px-4 py-6 backdrop-blur-sm sm:py-10"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <section
+        aria-labelledby={modalTitleId}
+        aria-modal="true"
+        role="dialog"
+        className="w-full max-w-2xl rounded-xl border border-slate-200 bg-white p-4 shadow-2xl dark:border-slate-800 dark:bg-slate-950 sm:p-6"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+              Card Detail
+            </p>
+            <h2
+              id={modalTitleId}
+              className="mt-1 break-words text-xl font-semibold tracking-tight text-slate-950 dark:text-slate-50"
+            >
+              {task.title}
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-9 shrink-0 items-center justify-center rounded-md border border-slate-300 bg-white px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
+          >
+            閉じる
+          </button>
+        </div>
+
+        <dl className="mt-5 grid gap-3 rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm dark:border-slate-800 dark:bg-slate-900/70 sm:grid-cols-3">
+          <div>
+            <dt className="text-xs font-medium text-slate-500 dark:text-slate-400">
+              ステータス
+            </dt>
+            <dd className="mt-1 font-medium text-slate-800 dark:text-slate-100">
+              {TASK_STATUS_LABELS[task.status]}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium text-slate-500 dark:text-slate-400">
+              作成日
+            </dt>
+            <dd className="mt-1 text-slate-700 dark:text-slate-200">
+              {formatDateTime(task.createdAt)}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium text-slate-500 dark:text-slate-400">
+              更新日
+            </dt>
+            <dd className="mt-1 text-slate-700 dark:text-slate-200">
+              {formatDateTime(task.updatedAt)}
+            </dd>
+          </div>
+        </dl>
+
+        <form
+          className="mt-5 grid gap-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            saveTask();
+          }}
+        >
+          <label className="grid gap-2" htmlFor={titleInputId}>
+            <span className="text-sm font-medium text-slate-700 dark:text-slate-200">
+              タイトル
+            </span>
+            <input
+              id={titleInputId}
+              type="text"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              className="h-11 rounded-md border border-slate-300 bg-white px-3 text-base text-slate-950 shadow-sm outline-none transition focus:border-slate-500 focus:ring-2 focus:ring-slate-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50 dark:focus:border-slate-400 dark:focus:ring-slate-800 sm:h-10 sm:text-sm"
+            />
+          </label>
+
+          <label className="grid gap-2" htmlFor={descriptionInputId}>
+            <span className="text-sm font-medium text-slate-700 dark:text-slate-200">
+              詳細
+            </span>
+            <textarea
+              id={descriptionInputId}
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              rows={5}
+              placeholder="詳細は未入力です。"
+              className="resize-none rounded-md border border-slate-300 bg-white px-3 py-2 text-base text-slate-950 shadow-sm outline-none transition placeholder:text-slate-400 focus:border-slate-500 focus:ring-2 focus:ring-slate-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50 dark:focus:border-slate-400 dark:focus:ring-slate-800 sm:text-sm"
+            />
+          </label>
+
+          <div className="flex flex-wrap justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="inline-flex h-10 flex-1 items-center justify-center rounded-md border border-slate-300 bg-white px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800 sm:flex-none"
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              disabled={!trimmedTitle}
+              className="inline-flex h-10 flex-1 items-center justify-center rounded-md bg-slate-950 px-3 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-300 dark:bg-slate-100 dark:text-slate-950 dark:hover:bg-white dark:disabled:bg-slate-700 dark:disabled:text-slate-400 sm:flex-none"
+            >
+              保存
+            </button>
+          </div>
+        </form>
+      </section>
+    </div>
+  );
+}
+
+function formatDateTime(value: string) {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return "不明";
+  }
+
+  return new Intl.DateTimeFormat("ja-JP", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}

--- a/components/KanbanBoard.tsx
+++ b/components/KanbanBoard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { CardDetailModal } from "@/components/CardDetailModal";
 import { KanbanColumn } from "@/components/KanbanColumn";
 import { createTask } from "@/lib/task";
 import { loadAppState, saveAppState } from "@/lib/storage";
@@ -17,6 +18,7 @@ export function KanbanBoard() {
   const [dropTargetStatus, setDropTargetStatus] = useState<TaskStatus | null>(
     null,
   );
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [hasLoadedStoredState, setHasLoadedStoredState] = useState(false);
 
   const updateTask = (
@@ -137,6 +139,10 @@ export function KanbanBoard() {
     );
   }, [tasks]);
 
+  const selectedTask = selectedTaskId
+    ? tasks.find((task) => task.id === selectedTaskId)
+    : undefined;
+
   if (!hasLoadedStoredState) {
     return (
       <div className="rounded-xl border border-slate-200 bg-slate-100/70 p-6 text-center text-sm text-slate-500 dark:border-slate-800 dark:bg-slate-900/70 dark:text-slate-400">
@@ -158,6 +164,7 @@ export function KanbanBoard() {
             isDropTarget={dropTargetStatus === status}
             onUpdateTask={updateTask}
             onDeleteTask={deleteTask}
+            onOpenTask={setSelectedTaskId}
             onDragStartTask={setDraggingTaskId}
             onDragEnterColumn={setDropTargetStatus}
             onDragEndTask={finishDragging}
@@ -177,6 +184,14 @@ export function KanbanBoard() {
           />
         ))}
       </div>
+      {selectedTask ? (
+        <CardDetailModal
+          key={selectedTask.id}
+          task={selectedTask}
+          onClose={() => setSelectedTaskId(null)}
+          onUpdateTask={updateTask}
+        />
+      ) : null}
     </div>
   );
 }

--- a/components/KanbanColumn.tsx
+++ b/components/KanbanColumn.tsx
@@ -15,6 +15,7 @@ type KanbanColumnProps = {
     input: Pick<Task, "title" | "description">,
   ) => void;
   onDeleteTask: (taskId: string) => void;
+  onOpenTask: (taskId: string) => void;
   onDragStartTask: (taskId: string) => void;
   onDragEnterColumn: (status: TaskStatus) => void;
   onDragEndTask: () => void;
@@ -30,6 +31,7 @@ export function KanbanColumn({
   isDropTarget,
   onUpdateTask,
   onDeleteTask,
+  onOpenTask,
   onDragStartTask,
   onDragEnterColumn,
   onDragEndTask,
@@ -87,6 +89,7 @@ export function KanbanColumn({
               isDragging={draggingTaskId === task.id}
               onUpdate={onUpdateTask}
               onDelete={onDeleteTask}
+              onOpen={onOpenTask}
               onDragStart={onDragStartTask}
               onDragEnd={onDragEndTask}
               onDragEnter={() => onDragEnterColumn(status)}

--- a/components/TaskCard.tsx
+++ b/components/TaskCard.tsx
@@ -11,6 +11,7 @@ type TaskCardProps = {
     input: Pick<Task, "title" | "description">,
   ) => void;
   onDelete: (taskId: string) => void;
+  onOpen: (taskId: string) => void;
   onDragStart: (taskId: string) => void;
   onDragEnter: () => void;
   onDragEnd: () => void;
@@ -22,6 +23,7 @@ export function TaskCard({
   isDragging,
   onUpdate,
   onDelete,
+  onOpen,
   onDragStart,
   onDragEnter,
   onDragEnd,
@@ -107,12 +109,25 @@ export function TaskCard({
   return (
     <article
       draggable
+      role="button"
+      tabIndex={0}
       aria-label={`${task.title} のタスクカード`}
       className={`group min-w-0 rounded-lg border border-slate-200 bg-white p-4 shadow-sm transition dark:border-slate-800 dark:bg-slate-950 ${
         isDragging
           ? "cursor-grabbing opacity-50 ring-2 ring-slate-300 dark:ring-slate-700"
           : "cursor-grab hover:-translate-y-0.5 hover:shadow-md"
       }`}
+      onClick={() => onOpen(task.id)}
+      onKeyDown={(event) => {
+        if (event.target !== event.currentTarget) {
+          return;
+        }
+
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onOpen(task.id);
+        }
+      }}
       onDragStart={(event: DragEvent<HTMLElement>) => {
         event.dataTransfer.effectAllowed = "move";
         event.dataTransfer.setData("text/plain", task.id);
@@ -157,14 +172,20 @@ export function TaskCard({
             <div className="mt-3 flex flex-wrap justify-end gap-2">
               <button
                 type="button"
-                onClick={() => setIsConfirmingDelete(false)}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setIsConfirmingDelete(false);
+                }}
                 className="inline-flex h-9 flex-1 items-center justify-center rounded-md border border-red-200 bg-white px-3 text-xs font-medium text-red-700 transition hover:bg-red-50 dark:border-red-900/70 dark:bg-slate-950 dark:text-red-300 dark:hover:bg-red-950/50 sm:h-8 sm:flex-none"
               >
                 キャンセル
               </button>
               <button
                 type="button"
-                onClick={() => onDelete(task.id)}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onDelete(task.id);
+                }}
                 className="inline-flex h-9 flex-1 items-center justify-center rounded-md bg-red-700 px-3 text-xs font-semibold text-white transition hover:bg-red-800 focus:outline-none focus:ring-2 focus:ring-red-400 dark:bg-red-500 dark:text-white dark:hover:bg-red-400 sm:h-8 sm:flex-none"
               >
                 削除する
@@ -175,7 +196,8 @@ export function TaskCard({
           <div className="flex flex-wrap items-center justify-end gap-2 opacity-100 transition sm:opacity-80 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100">
             <button
               type="button"
-              onClick={() => {
+              onClick={(event) => {
+                event.stopPropagation();
                 setIsConfirmingDelete(false);
                 resetForm();
                 setIsEditing(true);
@@ -186,7 +208,10 @@ export function TaskCard({
             </button>
             <button
               type="button"
-              onClick={() => setIsConfirmingDelete(true)}
+              onClick={(event) => {
+                event.stopPropagation();
+                setIsConfirmingDelete(true);
+              }}
               className="inline-flex h-9 items-center justify-center rounded-md px-3 text-xs font-medium text-red-600 transition hover:bg-red-50 hover:text-red-700 focus:outline-none focus:ring-2 focus:ring-red-300 dark:text-red-400 dark:hover:bg-red-950/40 dark:hover:text-red-300 sm:h-8 sm:px-2.5"
               aria-label={`${task.title} を削除`}
             >


### PR DESCRIPTION
## Summary
- Add a Trello-style card detail modal that opens from card click or keyboard activation.
- Show title, description, status, created date, and updated date in the modal.
- Allow editing title and description from the modal while preserving existing card actions and drag behavior.

## Test plan
- [x] npm run lint
- [x] npm run build
- [x] Browser verified card click opens the detail modal
- [x] Browser verified title and description edits update the card and persist after reload
- [x] Browser verified Escape closes the modal

Closes #24


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Users can now click on task cards to view full task details in a modal dialog
- Task detail modal supports editing of task titles and descriptions
- Modal displays task status and formatted timestamps
- Multiple ways to close the modal: close button, backdrop click, or Escape key

<!-- end of auto-generated comment: release notes by coderabbit.ai -->